### PR TITLE
Load gallery images without JavaScript

### DIFF
--- a/FastFriendlyClone/www.fastfriendlyrepair.com/gallery.html
+++ b/FastFriendlyClone/www.fastfriendlyrepair.com/gallery.html
@@ -874,7 +874,7 @@ fbq('track', 'PageView');
 </div> 
 </div> 
 </div> 
- <div class="dmRespRow" id="1037300085"> <div class="dmRespColsWrapper" id="1527276373"> <div class="dmRespCol large-12 medium-12 small-12" id="1933365748"> <div class="dmPhotoGallery newPhotoGallery dmPhotoGalleryResp u_1137804461" galleryoptionsparams="{thumbnailsPerRow: 3, rowsToShow: 3, imageScaleMethod: true}" data-desktop-layout="pinterest" data-desktop-columns="4" data-element-type="dPhotoGalleryId" data-desktop-text-layout="over" id="1137804461" data-placeholder="false" data-rows-to-show="4"> <ul class="dmPhotoGalleryHolder clearfix gallery shadowEffectToChildren gallery4inArow" id="1750014347"> <li class="photoGalleryThumbs" id="1683881016"> <div class="image-container" id="1529231829"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_0524.jpeg" id="1469585385"><img irh="" irw="" alt="A jeep is sitting on a lift in a garage." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_0524-1920w.jpeg" id="1875343226" class="" onerror="handleImageLoadError(this)"/></a> 
+ <div class="dmRespRow" id="1037300085"> <div class="dmRespColsWrapper" id="1527276373"> <div class="dmRespCol large-12 medium-12 small-12" id="1933365748"> <div class="dmPhotoGallery newPhotoGallery dmPhotoGalleryResp u_1137804461" galleryoptionsparams="{thumbnailsPerRow: 3, rowsToShow: 3, imageScaleMethod: true}" data-desktop-layout="pinterest" data-desktop-columns="4" data-element-type="dPhotoGalleryId" data-desktop-text-layout="over" id="1137804461" data-placeholder="false" data-rows-to-show="4"> <ul class="dmPhotoGalleryHolder clearfix gallery shadowEffectToChildren gallery4inArow" id="1750014347"> <li class="photoGalleryThumbs" id="1683881016"> <div class="image-container" id="1529231829"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_0524.jpeg" id="1469585385"><img irh="" irw="" alt="A jeep is sitting on a lift in a garage." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_0524-1920w.jpeg" id="1875343226" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1376623253"> <span class="caption-inner" id="1777324958"> <a class="caption-button dmWidget clearfix" id="1882466757"> <span class="iconBg" id="1262125554"> <span class="icon hasFontIcon icon-star" id="1255404505"></span> 
 </span> 
@@ -883,7 +883,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1115650058"> <div class="image-container" id="1677364758"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_0682.JPG" id="1591133907"><img irh="" irw="" alt="A trailer is sitting off the side of a being recovered." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_0682-1920w.JPG" id="1465232389" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1115650058"> <div class="image-container" id="1677364758"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_0682.JPG" id="1591133907"><img irh="" irw="" alt="A trailer is sitting off the side of a being recovered." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_0682-1920w.JPG" id="1465232389" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1079016649"> <span class="caption-inner" id="1653644902"> <a class="caption-button dmWidget clearfix" id="1438299232"> <span class="iconBg" id="1321469779"> <span class="icon hasFontIcon icon-star" id="1202701979"></span> 
 </span> 
@@ -892,7 +892,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1499867182"> <div class="image-container" id="1269790202"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_0652.jpeg" id="1587357632"><img irh="" irw="" alt="The engine of a truck is being dismantled in a garage." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_0652-1920w.jpeg" id="1527757498" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1499867182"> <div class="image-container" id="1269790202"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_0652.jpeg" id="1587357632"><img irh="" irw="" alt="The engine of a truck is being dismantled in a garage." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_0652-1920w.jpeg" id="1527757498" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1052084554"> <span class="caption-inner" id="1205972413"> <a class="caption-button dmWidget clearfix" id="1040631872"> <span class="iconBg" id="1943279901"> <span class="icon hasFontIcon icon-star" id="1765054030"></span> 
 </span> 
@@ -901,7 +901,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1912806735"> <div class="image-container" id="1307112654"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_0945.jpeg" id="1134241870"><img irh="" irw="" alt="A yellow flatbed tow truck is towing a red truck." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_0945-1920w.jpeg" id="1223133943" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1912806735"> <div class="image-container" id="1307112654"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_0945.jpeg" id="1134241870"><img irh="" irw="" alt="A yellow flatbed tow truck is towing a red truck." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_0945-1920w.jpeg" id="1223133943" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1987707789"> <span class="caption-inner" id="1354982403"> <a class="caption-button dmWidget clearfix" id="1678373068"> <span class="iconBg" id="1903075911"> <span class="icon hasFontIcon icon-star" id="1916943749"></span> 
 </span> 
@@ -910,7 +910,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1818058233"> <div class="image-container" id="1157532874"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_0716.jpeg" id="1666438654"><img irh="" irw="" alt="A group of men are working on a car engine in a garage." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_0716-1920w.jpeg" id="1466944731" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1818058233"> <div class="image-container" id="1157532874"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_0716.jpeg" id="1666438654"><img irh="" irw="" alt="A group of men are working on a car engine in a garage." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_0716-1920w.jpeg" id="1466944731" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1229263668"> <span class="caption-inner" id="1135243422"> <a class="caption-button dmWidget clearfix" id="1157029474"> <span class="iconBg" id="1620910777"> <span class="icon hasFontIcon icon-star" id="1316917196"></span> 
 </span> 
@@ -919,7 +919,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1047425153"> <div class="image-container" id="1451346009"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_0951.jpeg" id="1502509707"><img irh="" irw="" alt="A man is working on a jeep on a lift in a garage." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_0951-1920w.jpeg" id="1184692268" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1047425153"> <div class="image-container" id="1451346009"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_0951.jpeg" id="1502509707"><img irh="" irw="" alt="A man is working on a jeep on a lift in a garage." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_0951-1920w.jpeg" id="1184692268" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1564434985"> <span class="caption-inner" id="1992000975"> <a class="caption-button dmWidget clearfix" id="1034933722"> <span class="iconBg" id="1502228422"> <span class="icon hasFontIcon icon-star" id="1475895859"></span> 
 </span> 
@@ -928,7 +928,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1717062779"> <div class="image-container" id="1813164456"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_4404.JPG" id="1893962052"><img irh="" irw="" alt="A man is standing in front of a truck that says Fast Friendly Repair & Towing." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_4404-1920w.JPG" id="1973010895" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1717062779"> <div class="image-container" id="1813164456"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_4404.JPG" id="1893962052"><img irh="" irw="" alt="A man is standing in front of a truck that says Fast Friendly Repair & Towing." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_4404-1920w.JPG" id="1973010895" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1850880858"> <span class="caption-inner" id="1876948126"> <a class="caption-button dmWidget clearfix" id="1453430700"> <span class="iconBg" id="1914675695"> <span class="icon hasFontIcon icon-star" id="1911017923"></span> 
 </span> 
@@ -937,7 +937,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1930929436"> <div class="image-container" id="1008024594"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_1183.jpeg" id="1128099109"><img irh="" irw="" alt="A man is working on a car in a garage." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_1183-1920w.jpeg" id="1454669578" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1930929436"> <div class="image-container" id="1008024594"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_1183.jpeg" id="1128099109"><img irh="" irw="" alt="A man is working on a car in a garage." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_1183-1920w.jpeg" id="1454669578" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1011063156"> <span class="caption-inner" id="1514066051"> <a class="caption-button dmWidget clearfix" id="1755387897"> <span class="iconBg" id="1329560189"> <span class="icon hasFontIcon icon-star" id="1227671264"></span> 
 </span> 
@@ -946,7 +946,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1212249879"> <div class="image-container" id="1915303463"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_1231.jpeg" id="1798907863"><img irh="" irw="" alt="A black truck is sitting on a lift in a garage." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_1231-1920w.jpeg" id="1210604956" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1212249879"> <div class="image-container" id="1915303463"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_1231.jpeg" id="1798907863"><img irh="" irw="" alt="A black truck is sitting on a lift in a garage." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_1231-1920w.jpeg" id="1210604956" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1697604702"> <span class="caption-inner" id="1223694957"> <a class="caption-button dmWidget clearfix" id="1289875732"> <span class="iconBg" id="1818565088"> <span class="icon hasFontIcon icon-star" id="1263549406"></span> 
 </span> 
@@ -955,7 +955,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1531029351"> <div class="image-container" id="1605050143"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_1930.jpeg" id="1833939579"><img irh="" irw="" alt="A set of new truck tires and wheels." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_1930-1920w.jpeg" id="1728615697" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1531029351"> <div class="image-container" id="1605050143"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_1930.jpeg" id="1833939579"><img irh="" irw="" alt="A set of new truck tires and wheels." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_1930-1920w.jpeg" id="1728615697" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1017086092"> <span class="caption-inner" id="1848955589"> <a class="caption-button dmWidget clearfix" id="1913945474"> <span class="iconBg" id="1108470184"> <span class="icon hasFontIcon icon-star" id="1177756952"></span> 
 </span> 
@@ -964,7 +964,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1965016398"> <div class="image-container" id="1603497380"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_1691.JPG" id="1663262425"><img irh="" irw="" alt="A tow truck is towing a car in a parking lot at night." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_1691-1920w.JPG" id="1931559221" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1965016398"> <div class="image-container" id="1603497380"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_1691.JPG" id="1663262425"><img irh="" irw="" alt="A tow truck is towing a car in a parking lot at night." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_1691-1920w.JPG" id="1931559221" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1972288271"> <span class="caption-inner" id="1735763960"> <a class="caption-button dmWidget clearfix" id="1758769983"> <span class="iconBg" id="1242510948"> <span class="icon hasFontIcon icon-star" id="1875989320"></span> 
 </span> 
@@ -973,7 +973,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1508960558"> <div class="image-container" id="1149954197"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_2295.jpeg" id="1661674578"><img irh="" irw="" alt="A car engine is being dismantled in a garage." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_2295-1920w.jpeg" id="1712232995" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1508960558"> <div class="image-container" id="1149954197"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_2295.jpeg" id="1661674578"><img irh="" irw="" alt="A car engine is being dismantled in a garage." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_2295-1920w.jpeg" id="1712232995" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1639664661"> <span class="caption-inner" id="1734111434"> <a class="caption-button dmWidget clearfix" id="1017387271"> <span class="iconBg" id="1902573747"> <span class="icon hasFontIcon icon-star" id="1089612769"></span> 
 </span> 
@@ -982,7 +982,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1669360745"> <div class="image-container" id="1705098562"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_3824.jpeg" id="1112014820"><img irh="" irw="" alt="A tow truck is towing a dump truck down a dirt road." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_3824-1920w.jpeg" id="1346647732" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1669360745"> <div class="image-container" id="1705098562"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_3824.jpeg" id="1112014820"><img irh="" irw="" alt="A tow truck is towing a dump truck down a dirt road." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_3824-1920w.jpeg" id="1346647732" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1007155627"> <span class="caption-inner" id="1013180946"> <a class="caption-button dmWidget clearfix" id="1556688304"> <span class="iconBg" id="1939851450"> <span class="icon hasFontIcon icon-star" id="1546521666"></span> 
 </span> 
@@ -991,7 +991,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1168697789"> <div class="image-container" id="1672879899"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_3382.JPG" id="1279558574"><img irh="" irw="" alt="A tow truck is towing a classic car in a driveway." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_3382-1920w.JPG" id="1524716770" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1168697789"> <div class="image-container" id="1672879899"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_3382.JPG" id="1279558574"><img irh="" irw="" alt="A tow truck is towing a classic car in a driveway." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_3382-1920w.JPG" id="1524716770" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1895748440"> <span class="caption-inner" id="1047640983"> <a class="caption-button dmWidget clearfix" id="1867681908"> <span class="iconBg" id="1934825793"> <span class="icon hasFontIcon icon-star" id="1752228599"></span> 
 </span> 
@@ -1000,7 +1000,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1048869329"> <div class="image-container" id="1709619097"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_4209.jpeg" id="1323107396"><img irh="" irw="" alt="A tire is being balanced in a garage." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_4209-1920w.jpeg" id="1963124915" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1048869329"> <div class="image-container" id="1709619097"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_4209.jpeg" id="1323107396"><img irh="" irw="" alt="A tire is being balanced in a garage." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_4209-1920w.jpeg" id="1963124915" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1341093309"> <span class="caption-inner" id="1334773155"> <a class="caption-button dmWidget clearfix" id="1937942201"> <span class="iconBg" id="1954911234"> <span class="icon hasFontIcon icon-star" id="1793265541"></span> 
 </span> 
@@ -1009,7 +1009,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1760557492"> <div class="image-container" id="1509939929"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_4636.jpeg" id="1326489499"><img irh="" irw="" alt="A close up of a car engine with the hood open." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_4636-1920w.jpeg" id="1228257638" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1760557492"> <div class="image-container" id="1509939929"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_4636.jpeg" id="1326489499"><img irh="" irw="" alt="A close up of a car engine with the hood open." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_4636-1920w.jpeg" id="1228257638" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1670587089"> <span class="caption-inner" id="1749048220"> <a class="caption-button dmWidget clearfix" id="1801293190"> <span class="iconBg" id="1075317859"> <span class="icon hasFontIcon icon-star" id="1580299979"></span> 
 </span> 
@@ -1018,7 +1018,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1693392252"> <div class="image-container" id="1748917643"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_4412.jpeg" id="1696620922"><img irh="" irw="" alt="A man is working on a classic car on a lift in a garage." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_4412-1920w.jpeg" id="1741321574" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1693392252"> <div class="image-container" id="1748917643"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_4412.jpeg" id="1696620922"><img irh="" irw="" alt="A man is working on a classic car on a lift in a garage." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_4412-1920w.jpeg" id="1741321574" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1100367092"> <span class="caption-inner" id="1797132723"> <a class="caption-button dmWidget clearfix" id="1185399800"> <span class="iconBg" id="1729415157"> <span class="icon hasFontIcon icon-star" id="1588287486"></span> 
 </span> 
@@ -1027,7 +1027,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1238012150"> <div class="image-container" id="1594227454"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_4675.jpeg" id="1848394441"><img irh="" irw="" alt="A red tow truck is parked in a dirt field." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_4675-1920w.jpeg" id="1454303736" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1238012150"> <div class="image-container" id="1594227454"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_4675.jpeg" id="1848394441"><img irh="" irw="" alt="A red tow truck is parked in a dirt field." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_4675-1920w.jpeg" id="1454303736" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1271656728"> <span class="caption-inner" id="1844206138"> <a class="caption-button dmWidget clearfix" id="1146948064"> <span class="iconBg" id="1431098468"> <span class="icon hasFontIcon icon-star" id="1305597569"></span> 
 </span> 
@@ -1036,7 +1036,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1307516472"> <div class="image-container" id="1858886720"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_4860.jpeg" id="1427756811"><img irh="" irw="" alt="A GMC truck is being worked on in a garage." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_4860-1920w.jpeg" id="1967043103" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1307516472"> <div class="image-container" id="1858886720"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_4860.jpeg" id="1427756811"><img irh="" irw="" alt="A GMC truck is being worked on in a garage." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_4860-1920w.jpeg" id="1967043103" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1737145179"> <span class="caption-inner" id="1913545656"> <a class="caption-button dmWidget clearfix" id="1017546223"> <span class="iconBg" id="1539241642"> <span class="icon hasFontIcon icon-star" id="1112602423"></span> 
 </span> 
@@ -1045,7 +1045,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1798706399"> <div class="image-container" id="1901173401"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_5141.jpeg" id="1639226803"><img irh="" irw="" alt="A red tow truck is parked next to a white semi truck." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_5141-1920w.jpeg" id="1807126881" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1798706399"> <div class="image-container" id="1901173401"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_5141.jpeg" id="1639226803"><img irh="" irw="" alt="A red tow truck is parked next to a white semi truck." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_5141-1920w.jpeg" id="1807126881" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1640882860"> <span class="caption-inner" id="1986817346"> <a class="caption-button dmWidget clearfix" id="1411097399"> <span class="iconBg" id="1096142809"> <span class="icon hasFontIcon icon-star" id="1675342647"></span> 
 </span> 
@@ -1054,7 +1054,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1108405418"> <div class="image-container" id="1684579740"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_5532.jpeg" id="1593412622"><img irh="" irw="" alt="A lifted black truck is sitting on top of a lift in a garage." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_5532-1920w.jpeg" id="1827915955" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1108405418"> <div class="image-container" id="1684579740"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_5532.jpeg" id="1593412622"><img irh="" irw="" alt="A lifted black truck is sitting on top of a lift in a garage." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_5532-1920w.jpeg" id="1827915955" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1582698362"> <span class="caption-inner" id="1621461859"> <a class="caption-button dmWidget clearfix" id="1430459474"> <span class="iconBg" id="1971181678"> <span class="icon hasFontIcon icon-star" id="1042500330"></span> 
 </span> 
@@ -1063,7 +1063,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1468042374"> <div class="image-container" id="1959098792"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_5684.jpeg" id="1556699375"><img irh="" irw="" alt="A tow truck is recovering a semi on a snowy road." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_5684-1920w.jpeg" id="1758552131" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1468042374"> <div class="image-container" id="1959098792"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_5684.jpeg" id="1556699375"><img irh="" irw="" alt="A tow truck is recovering a semi on a snowy road." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_5684-1920w.jpeg" id="1758552131" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1023558210"> <span class="caption-inner" id="1295100112"> <a class="caption-button dmWidget clearfix" id="1127552577"> <span class="iconBg" id="1900208186"> <span class="icon hasFontIcon icon-star" id="1500001482"></span> 
 </span> 
@@ -1072,7 +1072,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1235572941"> <div class="image-container" id="1377853792"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_5797.JPG" id="1763845243"><img irh="" irw="" alt="Fast Friendly Repair & Towing in Painesville, OH donating kid's bicycles." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_5797-1920w.JPG" id="1537242949" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1235572941"> <div class="image-container" id="1377853792"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_5797.JPG" id="1763845243"><img irh="" irw="" alt="Fast Friendly Repair & Towing in Painesville, OH donating kid's bicycles." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_5797-1920w.JPG" id="1537242949" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1830704334"> <span class="caption-inner" id="1269587525"> <a class="caption-button dmWidget clearfix" id="1602006966"> <span class="iconBg" id="1960108119"> <span class="icon hasFontIcon icon-star" id="1667288801"></span> 
 </span> 
@@ -1081,7 +1081,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1093226862"> <div class="image-container" id="1558475137"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_5960+%281%29.JPG" id="1956217715"><img irh="" irw="" alt="A red and white tow truck is parked on the side of the road." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_5960+%281%29-1920w.JPG" id="1303518271" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1093226862"> <div class="image-container" id="1558475137"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_5960+%281%29.JPG" id="1956217715"><img irh="" irw="" alt="A red and white tow truck is parked on the side of the road." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_5960+%281%29-1920w.JPG" id="1303518271" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1451432148"> <span class="caption-inner" id="1574595497"> <a class="caption-button dmWidget clearfix" id="1225023869"> <span class="iconBg" id="1163875530"> <span class="icon hasFontIcon icon-star" id="1685839119"></span> 
 </span> 
@@ -1090,7 +1090,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1139342537"> <div class="image-container" id="1065684252"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_6130.jpeg" id="1795984391"><img irh="" irw="" alt="A pink chair is sitting in front of a trailer truck." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_6130-1920w.jpeg" id="1831046498" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1139342537"> <div class="image-container" id="1065684252"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_6130.jpeg" id="1795984391"><img irh="" irw="" alt="A pink chair is sitting in front of a trailer truck." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_6130-1920w.jpeg" id="1831046498" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1565753985"> <span class="caption-inner" id="1615359441"> <a class="caption-button dmWidget clearfix" id="1389499742"> <span class="iconBg" id="1080666470"> <span class="icon hasFontIcon icon-star" id="1801438455"></span> 
 </span> 
@@ -1099,7 +1099,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1515870744"> <div class="image-container" id="1356632629"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_6572.jpeg" id="1074324775"><img irh="" irw="" alt="A black car is parked next to an orange car in a garage." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_6572-1920w.jpeg" id="1598097289" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1515870744"> <div class="image-container" id="1356632629"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_6572.jpeg" id="1074324775"><img irh="" irw="" alt="A black car is parked next to an orange car in a garage." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_6572-1920w.jpeg" id="1598097289" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1021757316"> <span class="caption-inner" id="1765801272"> <a class="caption-button dmWidget clearfix" id="1655770490"> <span class="iconBg" id="1729317160"> <span class="icon hasFontIcon icon-star" id="1906072693"></span> 
 </span> 
@@ -1108,7 +1108,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1656508474"> <div class="image-container" id="1905216117"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_6644.jpeg" id="1804821080"><img irh="" irw="" alt="A red tow truck with doors open." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_6644-1920w.jpeg" id="1829635732" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1656508474"> <div class="image-container" id="1905216117"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_6644.jpeg" id="1804821080"><img irh="" irw="" alt="A red tow truck with doors open." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_6644-1920w.jpeg" id="1829635732" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1532239259"> <span class="caption-inner" id="1762512908"> <a class="caption-button dmWidget clearfix" id="1795513267"> <span class="iconBg" id="1400943858"> <span class="icon hasFontIcon icon-star" id="1046924943"></span> 
 </span> 
@@ -1117,7 +1117,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1096159393"> <div class="image-container" id="1303683370"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_6794.jpeg" id="1098504613"><img irh="" irw="" alt="A man is working on the engine of a truck in a garage." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_6794-1920w.jpeg" id="1640258911" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1096159393"> <div class="image-container" id="1303683370"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_6794.jpeg" id="1098504613"><img irh="" irw="" alt="A man is working on the engine of a truck in a garage." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_6794-1920w.jpeg" id="1640258911" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1754443841"> <span class="caption-inner" id="1242544469"> <a class="caption-button dmWidget clearfix" id="1092303944"> <span class="iconBg" id="1721933453"> <span class="icon hasFontIcon icon-star" id="1994020575"></span> 
 </span> 
@@ -1126,7 +1126,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1625368449"> <div class="image-container" id="1506958475"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_6841.jpeg" id="1905998318"><img irh="" irw="" alt="A man is working on a large engine in a garage." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_6841-1920w.jpeg" id="1912295484" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1625368449"> <div class="image-container" id="1506958475"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_6841.jpeg" id="1905998318"><img irh="" irw="" alt="A man is working on a large engine in a garage." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_6841-1920w.jpeg" id="1912295484" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1415551642"> <span class="caption-inner" id="1030020615"> <a class="caption-button dmWidget clearfix" id="1128806208"> <span class="iconBg" id="1530724392"> <span class="icon hasFontIcon icon-star" id="1639049115"></span> 
 </span> 
@@ -1135,7 +1135,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1218233338"> <div class="image-container" id="1820959743"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_7219.jpeg" id="1637465325"><img irh="" irw="" alt="A man is standing next to a tow truck in a garage." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_7219-1920w.jpeg" id="1255832067" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1218233338"> <div class="image-container" id="1820959743"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_7219.jpeg" id="1637465325"><img irh="" irw="" alt="A man is standing next to a tow truck in a garage." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_7219-1920w.jpeg" id="1255832067" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1541858113"> <span class="caption-inner" id="1950450214"> <a class="caption-button dmWidget clearfix" id="1325274476"> <span class="iconBg" id="1728226499"> <span class="icon hasFontIcon icon-star" id="1081085129"></span> 
 </span> 
@@ -1144,7 +1144,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1786132656"> <div class="image-container" id="1862740445"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_7109.JPG" id="1009740624"><img irh="" irw="" alt="A blue sports car is parked in front of a garage." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_7109-1920w.JPG" id="1642824966" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1786132656"> <div class="image-container" id="1862740445"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_7109.JPG" id="1009740624"><img irh="" irw="" alt="A blue sports car is parked in front of a garage." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_7109-1920w.JPG" id="1642824966" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1103540935"> <span class="caption-inner" id="1947557756"> <a class="caption-button dmWidget clearfix" id="1789626207"> <span class="iconBg" id="1126106485"> <span class="icon hasFontIcon icon-star" id="1300679641"></span> 
 </span> 
@@ -1153,7 +1153,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1264983296"> <div class="image-container" id="1876684537"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_7558.jpeg" id="1182172419"><img irh="" irw="" alt="A red tow truck is parked in a gravel lot." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_7558-1920w.jpeg" id="1552003838" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1264983296"> <div class="image-container" id="1876684537"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_7558.jpeg" id="1182172419"><img irh="" irw="" alt="A red tow truck is parked in a gravel lot." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_7558-1920w.jpeg" id="1552003838" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1939225819"> <span class="caption-inner" id="1820873561"> <a class="caption-button dmWidget clearfix" id="1904680538"> <span class="iconBg" id="1744569074"> <span class="icon hasFontIcon icon-star" id="1599650681"></span> 
 </span> 
@@ -1162,7 +1162,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1666469840"> <div class="image-container" id="1777755725"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_7460.jpeg" id="1270802279"><img irh="" irw="" alt="A truck is sitting on a lift in a garage." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_7460-1920w.jpeg" id="1708584432" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1666469840"> <div class="image-container" id="1777755725"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_7460.jpeg" id="1270802279"><img irh="" irw="" alt="A truck is sitting on a lift in a garage." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_7460-1920w.jpeg" id="1708584432" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1029482214"> <span class="caption-inner" id="1197070032"> <a class="caption-button dmWidget clearfix" id="1209912480"> <span class="iconBg" id="1749475787"> <span class="icon hasFontIcon icon-star" id="1754688353"></span> 
 </span> 
@@ -1171,7 +1171,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1337794027"> <div class="image-container" id="1256069135"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_8333.JPG" id="1476199761"><img irh="" irw="" alt="A red tow truck is parked next to a black suv" data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_8333-1920w.JPG" id="1685731076" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1337794027"> <div class="image-container" id="1256069135"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_8333.JPG" id="1476199761"><img irh="" irw="" alt="A red tow truck is parked next to a black suv" src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_8333-1920w.JPG" id="1685731076" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1582559965"> <span class="caption-inner" id="1626760133"> <a class="caption-button dmWidget clearfix" id="1155616956"> <span class="iconBg" id="1957815710"> <span class="icon hasFontIcon icon-star" id="1839429568"></span> 
 </span> 
@@ -1180,7 +1180,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1426931609"> <div class="image-container" id="1349600358"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_0009.JPG" id="1080586770"><img irh="" irw="" alt="A man is standing in front of a red truck on a lift in a garage." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_0009-1920w.JPG" id="1460869883" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1426931609"> <div class="image-container" id="1349600358"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_0009.JPG" id="1080586770"><img irh="" irw="" alt="A man is standing in front of a red truck on a lift in a garage." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_0009-1920w.JPG" id="1460869883" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1928318285"> <span class="caption-inner" id="1087802687"> <a class="caption-button dmWidget clearfix" id="1489625595"> <span class="iconBg" id="1802971491"> <span class="icon hasFontIcon icon-star" id="1441187551"></span> 
 </span> 
@@ -1189,7 +1189,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1364124937"> <div class="image-container" id="1170615681"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_7595.JPG" id="1010411831"><img irh="" irw="" alt="A tow truck is parked next to a semi truck on a dirt road." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_7595-1920w.JPG" id="1701466704" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1364124937"> <div class="image-container" id="1170615681"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_7595.JPG" id="1010411831"><img irh="" irw="" alt="A tow truck is parked next to a semi truck on a dirt road." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_7595-1920w.JPG" id="1701466704" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1049737617"> <span class="caption-inner" id="1531727912"> <a class="caption-button dmWidget clearfix" id="1379951722"> <span class="iconBg" id="1783591299"> <span class="icon hasFontIcon icon-star" id="1176493367"></span> 
 </span> 
@@ -1198,7 +1198,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1400453547"> <div class="image-container" id="1886991326"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_7603.JPG" id="1731062854"><img irh="" irw="" alt="A red and blue tow truck is parked in a warehouse." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_7603-1920w.JPG" id="1784315950" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1400453547"> <div class="image-container" id="1886991326"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_7603.JPG" id="1731062854"><img irh="" irw="" alt="A red and blue tow truck is parked in a warehouse." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_7603-1920w.JPG" id="1784315950" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1226656479"> <span class="caption-inner" id="1161089616"> <a class="caption-button dmWidget clearfix" id="1447681121"> <span class="iconBg" id="1497554642"> <span class="icon hasFontIcon icon-star" id="1502261453"></span> 
 </span> 
@@ -1207,7 +1207,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1605360571"> <div class="image-container" id="1122803961"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_9555.JPG" id="1898507518"><img irh="" irw="" alt="A tow truck is towing a semi truck in the snow." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_9555-1920w.JPG" id="1386809935" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1605360571"> <div class="image-container" id="1122803961"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_9555.JPG" id="1898507518"><img irh="" irw="" alt="A tow truck is towing a semi truck in the snow." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_9555-1920w.JPG" id="1386809935" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1556617501"> <span class="caption-inner" id="1509060463"> <a class="caption-button dmWidget clearfix" id="1811903899"> <span class="iconBg" id="1183467152"> <span class="icon hasFontIcon icon-star" id="1148361248"></span> 
 </span> 
@@ -1216,7 +1216,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1569150521"> <div class="image-container" id="1727451601"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_9782.jpeg" id="1015640992"><img irh="" irw="" alt="A bunch of tires and wheels are stacked on top of each other in a garage." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_9782-1920w.jpeg" id="1257097488" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1569150521"> <div class="image-container" id="1727451601"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_9782.jpeg" id="1015640992"><img irh="" irw="" alt="A bunch of tires and wheels are stacked on top of each other in a garage." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_9782-1920w.jpeg" id="1257097488" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1399079476"> <span class="caption-inner" id="1609637528"> <a class="caption-button dmWidget clearfix" id="1717106783"> <span class="iconBg" id="1441270528"> <span class="icon hasFontIcon icon-star" id="1224056336"></span> 
 </span> 
@@ -1225,7 +1225,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1174768732"> <div class="image-container" id="1012152384"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_8369.JPG" id="1554097476"><img irh="" irw="" alt="A red tow truck is parked on the side of the road." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_8369-1920w.JPG" id="1053980102" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1174768732"> <div class="image-container" id="1012152384"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_8369.JPG" id="1554097476"><img irh="" irw="" alt="A red tow truck is parked on the side of the road." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_8369-1920w.JPG" id="1053980102" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1704587282"> <span class="caption-inner" id="1239437417"> <a class="caption-button dmWidget clearfix" id="1926471938"> <span class="iconBg" id="1518115679"> <span class="icon hasFontIcon icon-star" id="1652431802"></span> 
 </span> 
@@ -1234,7 +1234,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1724191011"> <div class="image-container" id="1982661767"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_8367.JPG" id="1298387617"><img irh="" irw="" alt="A  Fast Friendly Repair & Towing tow truck is parked on the side of the road." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_8367-1920w.JPG" id="1068584492" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1724191011"> <div class="image-container" id="1982661767"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_8367.JPG" id="1298387617"><img irh="" irw="" alt="A  Fast Friendly Repair & Towing tow truck is parked on the side of the road." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_8367-1920w.JPG" id="1068584492" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1259300212"> <span class="caption-inner" id="1632986647"> <a class="caption-button dmWidget clearfix" id="1856702357"> <span class="iconBg" id="1099068208"> <span class="icon hasFontIcon icon-star" id="1667725373"></span> 
 </span> 
@@ -1243,7 +1243,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1644796609"> <div class="image-container" id="1777053959"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_2254-ca398773.jpeg" id="1197473282"><img irh="" irw="" alt="A tow truck with a black car on the back is parked in front of a garage." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_2254-ca398773-1920w.jpeg" id="1752112518" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1644796609"> <div class="image-container" id="1777053959"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_2254-ca398773.jpeg" id="1197473282"><img irh="" irw="" alt="A tow truck with a black car on the back is parked in front of a garage." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_2254-ca398773-1920w.jpeg" id="1752112518" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1906836379"> <span class="caption-inner" id="1803768737"> <a class="caption-button dmWidget clearfix" id="1564097184"> <span class="iconBg" id="1553056332"> <span class="icon hasFontIcon icon-star" id="1586218903"></span> 
 </span> 
@@ -1252,7 +1252,7 @@ fbq('track', 'PageView');
 </span> 
 </div> 
 </li> 
- <li class="photoGalleryThumbs" id="1450632285"> <div class="image-container" id="1652635225"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_2111-a8eacfdc.JPG" id="1056564642"><img irh="" irw="" alt="A red and white tow truck is towing a rv in a parking lot." data-src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_2111-a8eacfdc-1920w.JPG" id="1461675541" class="" onerror="handleImageLoadError(this)"/></a> 
+ <li class="photoGalleryThumbs" id="1450632285"> <div class="image-container" id="1652635225"> <a data-dm-multisize-attr="href" data-image-url="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/IMG_2111-a8eacfdc.JPG" id="1056564642"><img irh="" irw="" alt="A red and white tow truck is towing a rv in a parking lot." src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/IMG_2111-a8eacfdc-1920w.JPG" id="1461675541" class="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="caption-container" style="display:none" id="1947950214"> <span class="caption-inner" id="1950277809"> <a class="caption-button dmWidget clearfix" id="1988353805"> <span class="iconBg" id="1811986442"> <span class="icon hasFontIcon icon-star" id="1045500081"></span> 
 </span> 


### PR DESCRIPTION
## Summary
- Ensure gallery thumbnails load offline by moving `data-src` values to standard `src` attributes and removing `data-src`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ae274a67d08326b100593778f9f9f4