### PR TITLE
Load gallery CSS immediately

### DIFF
--- a/FastFriendlyClone/www.fastfriendlyrepair.com/gallery.html
+++ b/FastFriendlyClone/www.fastfriendlyrepair.com/gallery.html
@@ -1467,18 +1467,18 @@ and our automotive professionals always strive to provide our customers honest, 
 
 
 
-<link rel="preload" href="https://irp.cdn-website.com/fonts/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&amp;family=Montserrat:ital,wght@0,100..900;1,100..900&amp;family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&amp;family=Epilogue:ital,wght@0,100..900;1,100..900&amp;family=PT+Sans:ital,wght@0,400;0,700;1,400;1,700&amp;family=Roboto+Mono:ital,wght@0,100..700;1,100..700&amp;family=Source+Sans+Pro:ital,wght@0,200;0,300;0,400;0,600;0,700;0,900;1,200;1,300;1,400;1,600;1,700;1,900&amp;subset=latin-ext&amp;display=swap"  as="style" fetchpriority="low" onload="loadCSS(this)" />
+<link rel="stylesheet" href="https://irp.cdn-website.com/fonts/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&amp;family=Montserrat:ital,wght@0,100..900;1,100..900&amp;family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&amp;family=Epilogue:ital,wght@0,100..900;1,100..900&amp;family=PT+Sans:ital,wght@0,400;0,700;1,400;1,700&amp;family=Roboto+Mono:ital,wght@0,100..700;1,100..700&amp;family=Source+Sans+Pro:ital,wght@0,200;0,300;0,400;0,600;0,700;0,900;1,200;1,300;1,400;1,600;1,700;1,900&amp;subset=latin-ext&amp;display=swap" />
 
 
 
 
 
 <!-- RT CSS Include d-css-runtime-desktop-one-package-structured-global-->
-<link rel="preload" as="style" fetchpriority="low" onload="loadCSS(this)" href="../static.cdn-website.com/mnlt/production/5731/_dm/s/rt/dist/css/d-css-runtime-desktop-one-package-structured-global.min.css" />
+<link rel="stylesheet" href="../static.cdn-website.com/mnlt/production/5731/_dm/s/rt/dist/css/d-css-runtime-desktop-one-package-structured-global.min.css" />
 
 <!-- End of RT CSS Include -->
 
-<link rel="preload" href="../irp.cdn-website.com/WIDGET_CSS/047205a521e4447bedbe9984fbcb8c3a.css" id="widgetCSS" as="style" fetchpriority="low" onload="loadCSS(this)" />
+<link rel="stylesheet" href="../irp.cdn-website.com/WIDGET_CSS/047205a521e4447bedbe9984fbcb8c3a.css" id="widgetCSS" />
 
 <!-- Support `img` size attributes -->
 <style>img[width][height] {
@@ -1500,7 +1500,7 @@ and our automotive professionals always strive to provide our customers honest, 
 
 
 <!-- Site CSS -->
-<link rel="preload" href="../irp.cdn-website.com/8d8e069d/files/8d8e069d_1.minfad9.css?v=56" id="siteGlobalCss" as="style" fetchpriority="low" onload="loadCSS(this)" />
+<link rel="stylesheet" href="../irp.cdn-website.com/8d8e069d/files/8d8e069d_1.minfad9.css?v=56" id="siteGlobalCss" />
 
 
 


### PR DESCRIPTION
## Summary
- Replace CSS preload links in gallery page with standard stylesheet references so styles load without delay.

## Testing
- `curl -I http://localhost:8000/static.cdn-website.com/mnlt/production/5731/_dm/s/rt/dist/css/d-css-runtime-desktop-one-package-structured-global.min.css`
- `curl -I http://localhost:8000/irp.cdn-website.com/WIDGET_CSS/047205a521e4447bedbe9984fbcb8c3a.css`
- `curl -I "http://localhost:8000/irp.cdn-website.com/8d8e069d/files/8d8e069d_1.minfad9.css?v=56"`
- `node - <<'NODE'
const puppeteer = require('/root/.nvm/versions/node/v20.19.4/lib/node_modules/puppeteer');
(async () => {
  const browser = await puppeteer.launch({headless: 'new', args:['--no-sandbox','--disable-setuid-sandbox']});
  const page = await browser.newPage();
  await page.setViewport({width: 375, height: 667});
  await page.goto('http://localhost:8000/www.fastfriendlyrepair.com/gallery.html', {waitUntil: 'networkidle0'});
  const bodyWidth = await page.evaluate(() => window.getComputedStyle(document.body).width);
  console.log('body width', bodyWidth);
  await browser.close();
})();
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68ae274b2358832697137d6707af2a95