### PR TITLE
Fix gallery images not loading

### DIFF
--- a/FastFriendlyClone/www.fastfriendlyrepair.com/gallery.html
+++ b/FastFriendlyClone/www.fastfriendlyrepair.com/gallery.html
@@ -49,6 +49,12 @@
     background-image: none !important;
   }
 </style>
+<script>
+  function handleImageLoadError(img) {
+    console.warn("Image failed to load", img.src);
+    img.style.display = "none";
+  }
+</script>
 
 
 <script type="text/javascript">
@@ -270,7 +276,7 @@
 <!--Add favorites icons-->
 
 <link rel="apple-touch-icon"
-      href="../irp.cdn-website.com/8d8e069d/dms3rep/multi/FastFriendly.png"/>
+      href="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/FastFriendly.png"/>
 
 <link rel="icon" type="image/x-icon" href="https://irp.cdn-website.com/8d8e069d/site_favicon_16_1702065794596.ico"/>
 
@@ -761,7 +767,7 @@ fbq('track', 'PageView');
 </div> 
  <div class="layout-drawer-overlay" id="layout-drawer-overlay"></div> 
 </div> 
- <div class="site_content"> <div id="hamburger-header-container" class="showOnMedium hamburger-header-container p_hfcontainer"> <div id="hamburger-header" class="hamburger-header p_hfcontainer" layout="44dc38f951e9489490b055748e10ba9f===header" data-scrollable-target="body" data-scroll-responder-id="hamburger-header"> <div class="u_1705692124 dmRespRow" style="text-align: center;" id="1705692124"> <div class="dmRespColsWrapper" id="1469942216"> <div class="dmRespCol small-12 u_1655486006 large-6 medium-6" id="1655486006"> <div class="u_1923160809 imageWidget align-center" data-element-type="image" data-widget-type="image" id="1923160809" data-binding="W3siYmluZGluZ05hbWUiOiJpbWFnZSIsInZhbHVlIjoic2l0ZV9pbWFnZXMubG9nbyJ9XQ=="> <a href="index.html" id="1573522578" file="false"><img src="../lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/306146253_519065463561363_1727607050829971241_n-ddb4fdde-1920w.jpg" id="1761992403" class="" data-dm-image-path="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/306146253_519065463561363_1727607050829971241_n-ddb4fdde.jpg" width="0.0" height="0.0" alt="Fast Friendly Repair & Towing in Painesville, OH" data-diy-image="" onerror="handleImageLoadError(this)"/></a> 
+ <div class="site_content"> <div id="hamburger-header-container" class="showOnMedium hamburger-header-container p_hfcontainer"> <div id="hamburger-header" class="hamburger-header p_hfcontainer" layout="44dc38f951e9489490b055748e10ba9f===header" data-scrollable-target="body" data-scroll-responder-id="hamburger-header"> <div class="u_1705692124 dmRespRow" style="text-align: center;" id="1705692124"> <div class="dmRespColsWrapper" id="1469942216"> <div class="dmRespCol small-12 u_1655486006 large-6 medium-6" id="1655486006"> <div class="u_1923160809 imageWidget align-center" data-element-type="image" data-widget-type="image" id="1923160809" data-binding="W3siYmluZGluZ05hbWUiOiJpbWFnZSIsInZhbHVlIjoic2l0ZV9pbWFnZXMubG9nbyJ9XQ=="> <a href="index.html" id="1573522578" file="false"><img src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/306146253_519065463561363_1727607050829971241_n-ddb4fdde-1920w.jpg" id="1761992403" class="" data-dm-image-path="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/306146253_519065463561363_1727607050829971241_n-ddb4fdde.jpg" width="0.0" height="0.0" alt="Fast Friendly Repair & Towing in Painesville, OH" data-diy-image="" onerror="handleImageLoadError(this)"/></a> 
 </div> 
 </div> 
  <div class="dmRespCol large-6 medium-6 small-12" id="1353665085"> <a data-display-type="block" class="align-center dmButtonLink dmWidget dmWwr default dmOnlyButton dmDefaultGradient" file="false" href="tel:(440) 477-3206" data-element-type="dButtonLinkId" id="1110585285"> <span class="iconBg" aria-hidden="true" id="1349011194"> <span class="icon hasFontIcon icon-star" id="1788983296"></span> 
@@ -777,7 +783,7 @@ fbq('track', 'PageView');
  <span class="hamburger__slice"></span> 
  <span class="hamburger__slice"></span> 
 </button> 
- <div class="dmHeaderContainer fHeader d-header-wrapper showOnLarge"> <div id="hcontainer" class="u_hcontainer dmHeader p_hfcontainer" freeheader="true" headerlayout="b58ba5b5703b4cd7b5f5f7951565dc87===horizontal-layout-5" layout="7f3c1de367df47d5b45ab63d33101c7b===header"> <div dm:templateorder="85" class="dmHeaderResp dmHeaderStack noSwitch" id="1709005236"> <div class="dmRespRow dmDefaultListContentRow u_1979947330 fullBleedChanged fullBleedMode" style="text-align:center" id="1979947330"> <div class="dmRespColsWrapper" id="1122924284"> <div class="u_1258141954 small-12 dmRespCol large-2 medium-2" id="1258141954"> <div class="u_1446973368 imageWidget align-center" data-widget-type="image" id="1446973368" data-element-type="image" data-binding="W3siYmluZGluZ05hbWUiOiJpbWFnZSIsInZhbHVlIjoic2l0ZV9pbWFnZXMubG9nbyJ9XQ=="> <a href="index.html" id="1995522780"><img src="../lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/306146253_519065463561363_1727607050829971241_n-ddb4fdde-201w.jpg" id="1064091485" class="" data-dm-image-path="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/306146253_519065463561363_1727607050829971241_n-ddb4fdde.jpg" alt="Fast Friendly Repair & Towing in Painesville, OH" data-diy-image="" onerror="handleImageLoadError(this)" height="123.453125" width="167.5"/></a> 
+ <div class="dmHeaderContainer fHeader d-header-wrapper showOnLarge"> <div id="hcontainer" class="u_hcontainer dmHeader p_hfcontainer" freeheader="true" headerlayout="b58ba5b5703b4cd7b5f5f7951565dc87===horizontal-layout-5" layout="7f3c1de367df47d5b45ab63d33101c7b===header"> <div dm:templateorder="85" class="dmHeaderResp dmHeaderStack noSwitch" id="1709005236"> <div class="dmRespRow dmDefaultListContentRow u_1979947330 fullBleedChanged fullBleedMode" style="text-align:center" id="1979947330"> <div class="dmRespColsWrapper" id="1122924284"> <div class="u_1258141954 small-12 dmRespCol large-2 medium-2" id="1258141954"> <div class="u_1446973368 imageWidget align-center" data-widget-type="image" id="1446973368" data-element-type="image" data-binding="W3siYmluZGluZ05hbWUiOiJpbWFnZSIsInZhbHVlIjoic2l0ZV9pbWFnZXMubG9nbyJ9XQ=="> <a href="index.html" id="1995522780"><img src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/306146253_519065463561363_1727607050829971241_n-ddb4fdde-201w.jpg" id="1064091485" class="" data-dm-image-path="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/306146253_519065463561363_1727607050829971241_n-ddb4fdde.jpg" alt="Fast Friendly Repair & Towing in Painesville, OH" data-diy-image="" onerror="handleImageLoadError(this)" height="123.453125" width="167.5"/></a> 
 </div> 
 </div> 
  <div class="u_1756767336 dmRespCol small-12 large-8 medium-8" id="1756767336"> <span id="1402671018"></span> 
@@ -1279,11 +1285,11 @@ fbq('track', 'PageView');
 </div> 
 </div> 
 </div> 
- <div class="dmFooterContainer"> <div id="fcontainer" class="u_fcontainer f_hcontainer dmFooter p_hfcontainer"> <div dm:templateorder="250" class="dmFooterResp generalFooter" id="1943048428"> <div class="u_1432758778 dmRespRow fullBleedChanged fullBleedMode hide-for-small" id="1432758778"> <div class="dmRespColsWrapper" id="1133779662"> <div class="dmRespCol large-12 medium-12 small-12" id="1764624781"> <div class="u_1986509081 imageWidget align-center" data-element-type="image" data-widget-type="image" id="1986509081"><img src="../lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/AdobeStock_535665787-2fc9d1b8-963aa8f7-d372d2c3-2304w.png" alt="" id="1471034595" class="" data-dm-image-path="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/AdobeStock_535665787-2fc9d1b8-963aa8f7-d372d2c3.png" width="1920" height="193" onerror="handleImageLoadError(this)"/></div> 
+ <div class="dmFooterContainer"> <div id="fcontainer" class="u_fcontainer f_hcontainer dmFooter p_hfcontainer"> <div dm:templateorder="250" class="dmFooterResp generalFooter" id="1943048428"> <div class="u_1432758778 dmRespRow fullBleedChanged fullBleedMode hide-for-small" id="1432758778"> <div class="dmRespColsWrapper" id="1133779662"> <div class="dmRespCol large-12 medium-12 small-12" id="1764624781"> <div class="u_1986509081 imageWidget align-center" data-element-type="image" data-widget-type="image" id="1986509081"><img src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/AdobeStock_535665787-2fc9d1b8-963aa8f7-d372d2c3-2304w.png" alt="" id="1471034595" class="" data-dm-image-path="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/AdobeStock_535665787-2fc9d1b8-963aa8f7-d372d2c3.png" width="1920" height="193" onerror="handleImageLoadError(this)"/></div> 
 </div> 
 </div> 
 </div> 
- <div class="dmRespRow u_1080973458" id="1080973458"> <div class="dmRespColsWrapper" id="1176159225"> <div class="dmRespCol small-12 large-4 medium-4" id="1678459290"> <div class="u_1379354287 imageWidget align-center" data-element-type="image" data-widget-type="image" id="1379354287"> <a href="index.html" id="1039223134"><img src="../lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/306146253_519065463561363_1727607050829971241_n-ddb4fdde-352w.jpg" alt="Fast Friendly Repair & Towing in Painesville, OH" id="1130296205" class="" data-dm-image-path="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/306146253_519065463561363_1727607050829971241_n-ddb4fdde.jpg" width="232" height="171" onerror="handleImageLoadError(this)"/></a> 
+ <div class="dmRespRow u_1080973458" id="1080973458"> <div class="dmRespColsWrapper" id="1176159225"> <div class="dmRespCol small-12 large-4 medium-4" id="1678459290"> <div class="u_1379354287 imageWidget align-center" data-element-type="image" data-widget-type="image" id="1379354287"> <a href="index.html" id="1039223134"><img src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/306146253_519065463561363_1727607050829971241_n-ddb4fdde-352w.jpg" alt="Fast Friendly Repair & Towing in Painesville, OH" id="1130296205" class="" data-dm-image-path="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/306146253_519065463561363_1727607050829971241_n-ddb4fdde.jpg" width="232" height="171" onerror="handleImageLoadError(this)"/></a> 
 </div> 
  <div class="u_1797134932 dmNewParagraph" data-element-type="paragraph" data-version="5" id="1797134932" style="transition: opacity 1s ease-in-out 0s;" new-inline-bind-applied="true" data-diy-text=""><p class="m-size-10 size-14"><span class="font-size-14 m-font-size-10" style="display: initial;"><span class="inline-data-binding" data-encoded-value="RmFzdCBGcmllbmRseSBSZXBhaXIgJiBUb3dpbmc=" data-inline-binding="content_library.global.company_name">Fast Friendly Repair &amp; Towing</span> 
 is honored to serve the community of&nbsp;<span class="inline-data-binding" data-encoded-value="UGFpbmVzdmlsbGUsIE9I" data-inline-binding="site_text.city / st">Painesville, OH</span> 
@@ -1414,7 +1420,7 @@ and our automotive professionals always strive to provide our customers honest, 
 </div> 
 </div> 
 </div> 
- <div class="u_1479907475 dmRespCol small-12 large-4 medium-4" id="1479907475"> <div class="u_1958982345 imageWidget align-center" data-element-type="image" data-widget-type="image" id="1958982345"> <a href="http://www.whyoptimize.com/" id="1405308801" class="" target="_blank" file="false"><img src="../lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/ODM%2bO-57w.png" alt="Optimize Digital Marketing in Oakdale, MN" id="1332188680" class="" data-dm-image-path="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/ODM+O.png" width="1920" height="1728" onerror="handleImageLoadError(this)"/></a> 
+ <div class="u_1479907475 dmRespCol small-12 large-4 medium-4" id="1479907475"> <div class="u_1958982345 imageWidget align-center" data-element-type="image" data-widget-type="image" id="1958982345"> <a href="http://www.whyoptimize.com/" id="1405308801" class="" target="_blank" file="false"><img src="https://lirp.cdn-website.com/8d8e069d/dms3rep/multi/opt/ODM%2bO-57w.png" alt="Optimize Digital Marketing in Oakdale, MN" id="1332188680" class="" data-dm-image-path="https://irp.cdn-website.com/8d8e069d/dms3rep/multi/ODM+O.png" width="1920" height="1728" onerror="handleImageLoadError(this)"/></a> 
 </div> 
 </div> 
 </div> 
@@ -1486,7 +1492,7 @@ and our automotive professionals always strive to provide our customers honest, 
 
 <!-- End of RT CSS Include -->
 
-<link rel="stylesheet" href="../irp.cdn-website.com/WIDGET_CSS/047205a521e4447bedbe9984fbcb8c3a.css" id="widgetCSS" />
+<link rel="stylesheet" href="https://irp.cdn-website.com/WIDGET_CSS/047205a521e4447bedbe9984fbcb8c3a.css" id="widgetCSS" />
 
 <!-- Support `img` size attributes -->
 <style>img[width][height] {
@@ -1508,7 +1514,7 @@ and our automotive professionals always strive to provide our customers honest, 
 
 
 <!-- Site CSS -->
-<link rel="stylesheet" href="../irp.cdn-website.com/8d8e069d/files/8d8e069d_1.minfad9.css?v=56" id="siteGlobalCss" />
+<link rel="stylesheet" href="https://irp.cdn-website.com/8d8e069d/files/8d8e069d_1.minfad9.css?v=56" id="siteGlobalCss" />
 
 
 


### PR DESCRIPTION
## Summary
- Restore gallery image links to absolute CDN paths
- Add image load error handler to hide broken images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3a637f28832689641db136e72e74